### PR TITLE
directive stops the video stream when its $scope is '$destroy'ed

### DIFF
--- a/app/scripts/webcam.js
+++ b/app/scripts/webcam.js
@@ -30,8 +30,21 @@ angular.module('webcam', [])
         placeholder: '='
       },
       link: function postLink($scope, element) {
+        var videoElem, videoStream;
+
+        $scope.$on('$destroy', function() {
+          if (!!videoStream && typeof videoStream.stop === 'function') {
+            videoStream.stop();
+          }
+          if (!!videoElem) {
+            videoElem.src = null;
+          }
+        });
+
         // called when camera stream is loaded
         var onSuccess = function onSuccess(stream) {
+          videoStream = stream;
+
           // Firefox supports a src object
           if (navigator.mozGetUserMedia) {
             videoElem.mozSrcObject = stream;
@@ -64,7 +77,7 @@ angular.module('webcam', [])
           return;
         };
 
-        var videoElem = document.createElement('video');
+        videoElem = document.createElement('video');
         videoElem.setAttribute('class', 'webcam-live');
         videoElem.setAttribute('autoplay', '');
         element.append(videoElem);


### PR DESCRIPTION
I noticed an issue when the webcam directive is used in an app with multiple views. After switching views the webcam is still on (a green 'recording' light next to the webcam and an indicator in the browser).

The solution to this appears to be to call `stop()` on the video stream when the view is unloaded. I did this by hooking into the webcam $scope's $destroy event, which seemed the most appropriate place to put this logic. (Bug: Chrome on the desktop still displays an indicator in the omnibar, but the webcam recording indicator does turn off. I consider the indicator not going away to be Chrome's problem).

This seems like the kind of thing that could be testable. But it seems like there is a lot of mocking to do for that to be possible (having now looked at the tests I see they are not very thorough :frowning:). Instead I have put together two branches based off `gh-pages`.
- The problem can be seen on [this branch](https://github.com/bmatsuo/webcam-directive/tree/gh-pages-demos/scope-destroy/problem) (using the master webcam-directive js)
- The fix from this branch can be seen on [this branch](https://github.com/bmatsuo/webcam-directive/tree/gh-pages-demos/scope-destroy/fixed)

**Note**: you do have to be careful about `git submodule update` when you flip between those branches
