### PR TITLE
allow setting which device/media source to use. 

### DIFF
--- a/app/scripts/webcam.js
+++ b/app/scripts/webcam.js
@@ -2,6 +2,7 @@
  * Webcam Directive
  *
  * (c) Jonas Hartmann http://jonashartmann.github.io/webcam-directive
+ * (c) Tom Brewe (addition to allow different media sources) June 2015
  * License: MIT
  *
  * @version: 3.0.0
@@ -120,7 +121,27 @@ angular.module('webcam', [])
             return;
           }
 
-          var mediaConstraint = { video: true, audio: false };
+          // Tom Brewe --->
+
+          var mediaConstraint;
+          var video_;
+
+          // if we got to choose a source
+          if($scope.config.source !== undefined) {
+            video_ = { optional: [{sourceId: $scope.config.source.id}] };
+          } else {
+            video_= true;
+          }
+
+            mediaConstraint =
+            {
+              video: video_,
+              audio: false
+            };
+
+          // <--- Tom Brewe
+
+
           navigator.getMedia(mediaConstraint, onSuccess, onFailure);
 
           /* Start streaming the webcam data when the video element can play


### PR DESCRIPTION
this is useful for mobile devices where there might not be a chooser for multiple devices, but the first best is used (chrome, as of writing this commit message).

To init the element you would do something like this in your client code:

```.js
var videoSources;
if (videoSources === undefined) {
		if (MediaStreamTrack.getSources !== undefined) {
			MediaStreamTrack.getSources(function(sources) {
				videoSources = sources; // filter for video

				console.log("all possible media sources --->");
				for (var i = 0; i < videoSources.length; i++) {
					console.log(videoSources[i].kind);
				}
			});
		}
	}

	$scope.liveChannel = {
		// the fields below are all optional
		videoHeight: 800,
		videoWidth: 600,
		video: null, // Will reference the video element on success
		source: videoSources[2]
	};
```