### PR TITLE
Deactivate camera using MediaStreamTrack.stop()

### DIFF
--- a/app/scripts/webcam.js
+++ b/app/scripts/webcam.js
@@ -51,8 +51,12 @@ angular.module('webcam', [])
         };
 
         var onDestroy = function onDestroy() {
-          if (!!videoStream && typeof videoStream.stop === 'function') {
-            videoStream.stop();
+          if (!!videoStream) {
+            if(typeof videoStream.stop === 'function') {
+              videoStream.stop();
+            } else if (typeof videoStream.getTracks === 'function') {
+              videoStream.getTracks()[0].stop();
+            }
           }
           if (!!videoElem) {
             delete videoElem.src;


### PR DESCRIPTION
Chrome 47 removes `videoStream.stop()`. Instead you have to use `videoStream.getTracks()[0].stop()`. 

I only tested this change in Chrome 46 (current) & 47 (beta).