### PR TITLE
Replace deprecated mediaStream.stop() with mediaStreamTrack.stop()

### DIFF
--- a/app/scripts/webcam.js
+++ b/app/scripts/webcam.js
@@ -51,8 +51,19 @@ angular.module('webcam', [])
         };
 
         var onDestroy = function onDestroy() {
-          if (!!videoStream && typeof videoStream.stop === 'function') {
-            videoStream.stop();
+          if (!!videoStream ) {
+            if(videoStream.getVideoTracks) {
+                // get video track to call stop in it
+                // videoStream.stop() is deprecated and may be removed in the
+                // near future
+                var tracks = videoStream.getVideoTracks();
+                if (tracks && tracks[0] && tracks[0].stop) {
+                    tracks[0].stop();
+                }
+            } else if (videoStream.stop) {
+                // deprecated, may be removed in the near future
+                videoStream.stop();
+            }
           }
           if (!!videoElem) {
             delete videoElem.src;

--- a/app/scripts/webcam.js
+++ b/app/scripts/webcam.js
@@ -52,10 +52,13 @@ angular.module('webcam', [])
 
         var onDestroy = function onDestroy() {
           if (!!videoStream ) {
-            if(videoStream.getVideoTracks) {
+            var checker = typeof videoStream.getVideoTracks === 'function';
+            if(videoStream.getVideoTracks && checker) {
               // get video track to call stop in it
               // videoStream.stop() is deprecated and may be removed in the
               // near future
+              // ENSURE THIS IS CHECKED FIRST BEFORE THE FALLBACK
+              // videoStream.stop()
               var tracks = videoStream.getVideoTracks();
               if (tracks && tracks[0] && tracks[0].stop) {
                 tracks[0].stop();

--- a/app/scripts/webcam.js
+++ b/app/scripts/webcam.js
@@ -53,16 +53,16 @@ angular.module('webcam', [])
         var onDestroy = function onDestroy() {
           if (!!videoStream ) {
             if(videoStream.getVideoTracks) {
-                // get video track to call stop in it
-                // videoStream.stop() is deprecated and may be removed in the
-                // near future
-                var tracks = videoStream.getVideoTracks();
-                if (tracks && tracks[0] && tracks[0].stop) {
-                    tracks[0].stop();
-                }
+              // get video track to call stop in it
+              // videoStream.stop() is deprecated and may be removed in the
+              // near future
+              var tracks = videoStream.getVideoTracks();
+              if (tracks && tracks[0] && tracks[0].stop) {
+                tracks[0].stop();
+              }
             } else if (videoStream.stop) {
-                // deprecated, may be removed in the near future
-                videoStream.stop();
+              // deprecated, may be removed in the near future
+              videoStream.stop();
             }
           }
           if (!!videoElem) {


### PR DESCRIPTION
hey @jonashartmann , `MediaStream.stop()` is **deprecated** and will be removed in M47, around November 2015. Well we are past November already.

Chrome 47 has already removed it. This `PR` fixes the issue.