### PR TITLE
Adding property used by browserify (CommonJS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "author": "Jonas Hartmann",
   "version": "3.1.1",
   "dependencies": {},
+  "main": "./dist/webcam.min.js",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-bower-requirejs": "~0.4.1",


### PR DESCRIPTION
Browserify (CommonJS) looks to this (main) property to realize the dependency injection via 'require'.

Ex: var webcam = require('webcam');
