### PR TITLE
set stream updated for modern browsers

### DIFF
--- a/app/scripts/webcam.js
+++ b/app/scripts/webcam.js
@@ -79,14 +79,15 @@ angular.module('webcam', [])
         var onSuccess = function onSuccess(stream) {
           videoStream = stream;
 
-          if (window.hasModernUserMedia) {
+          try {
             videoElem.srcObject = stream;
-            // Firefox supports a src object
-          } else if (navigator.mozGetUserMedia) {
-            videoElem.mozSrcObject = stream;
-          } else {
-            var vendorURL = window.URL || window.webkitURL;
-            videoElem.src = vendorURL.createObjectURL(stream);
+          } catch(err) {
+            if (navigator.mozGetUserMedia) {
+              videoElem.mozSrcObject = stream;
+            } else {
+              var vendorURL = window.URL || window.webkitURL;
+              videoElem.src = vendorURL.createObjectURL(stream);
+            }
           }
 
           /* Start playing the video to show the stream from the webcam */


### PR DESCRIPTION
`createObjectURL ` is not a valid function in safari/ios. 

https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL states that all browsers only need to set the srcObject directly to the stream rather than creating the object url.