### PR TITLE
removing webcam auto start

### DIFF
--- a/app/scripts/webcam.js
+++ b/app/scripts/webcam.js
@@ -190,8 +190,6 @@ angular.module('webcam', [])
         $scope.$on('START_WEBCAM', startWebcam);
         $scope.$on('STOP_WEBCAM', stopWebcam);
 
-        startWebcam();
-
       }
     };
   });


### PR DESCRIPTION
starting the webcam by default causes it to load unnecessarily.

disabling the automatic start of the webcam leaves it at the discretion of the developer to start the webcam on demand, as at the click of a button, for example.